### PR TITLE
Solve(bfs): BOJ 18352 "특정 거리의 도시 찾기" 문제 풀이

### DIFF
--- a/boj/solved/bfs/18352/Main.java
+++ b/boj/solved/bfs/18352/Main.java
@@ -1,0 +1,72 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int n, m, k, x;
+    static HashMap<Integer, List<Integer>> hm = new HashMap<>();
+    static int[] res;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        x = Integer.parseInt(st.nextToken());
+
+        for (int i = 1; i <= n; i++) {
+            hm.put(i, new ArrayList<>());
+        }
+        res = new int[n + 1];
+        Arrays.fill(res, 300002);
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            hm.get(start).add(end);
+        }
+        bfs(x);
+
+        StringBuilder sb = new StringBuilder();
+        int count = 0;
+        for (int i = 1; i <= n; i++) {
+            if (res[i] == k) {
+                count += 1;
+                sb.append(i + "\n");
+            }
+        }
+        if (count == 0) {
+            System.out.println(-1);
+        } else {
+            System.out.print(sb);
+        }
+    }
+
+    /* 
+    방문 처리하면서 최단 거리를 갱신하며 res 배열에 수집
+    */
+    public static void bfs(int start) {
+        Queue<Integer> q = new LinkedList<>();
+        boolean[] visited = new boolean[n + 1];
+
+        res[start] = 0;
+        visited[start] = true;
+        q.add(start);
+
+        while (!q.isEmpty()) {
+            int tmp = q.poll();
+
+            for (int a : hm.get(tmp)) {
+                if (visited[a])
+                    continue;
+
+                if (res[a] > res[tmp] + 1) {
+                    visited[a] = true;
+                    res[a] = res[tmp] + 1;
+                    q.add(a);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ / Programmers
- 문제 번호: 18352
- 문제 링크: https://www.acmicpc.net/problem/18352
- 분류: bfs

---

## 1) 최종 풀이 요약

- 해결 방법 핵심: bfs를 활용한 최단 거리 탐색 후 일치하는 거리의 번호 출력
- 사용한 알고리즘/자료구조: bfs

## 2) 시간/공간 복잡도

- 시간 복잡도: bfs 이므로 O(N+M)
- 공간 복잡도: O(N+M)

## 3) 고민사항

- 최소거리 알고리즘으로 Dijkstra 알고리즘을 고려하였지만, 도로의 거리를 1로 제한하였기 때문 단순 bfs로 구현
- 문제 풀이 후 코드를 점검하면서 최소 거리를 갱신할 필요가 없다는 생각을 함, 어짜피 큐에는 거리가 항상 증가하게 정렬됨(64번째 줄 조건문 제거해도 상관 없는걸 알 수 있음)

---