### PR TITLE
Solve(implements): BOJ 20164 "홀수 홀릭 호석" 문제 풀이

### DIFF
--- a/boj/solved/implements/20164/Main.java
+++ b/boj/solved/implements/20164/Main.java
@@ -1,0 +1,55 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static String n;
+    static int max = 0;
+    static int min = 1000000;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = br.readLine();
+
+        func(n, 0);
+        System.out.println(min + " " + max);
+    }
+    
+    // 홀수 개수 찾기
+    public static int checkOdd(String num) {
+        int sum = 0;
+        for(int i =0;i<num.length();i++) {
+            int tmp = Integer.parseInt(num.substring(i, i+1));
+            if(tmp %2 == 1) {
+                sum +=1;
+            }
+        }
+        return sum;
+    }
+
+    public static int func(String num, int lastSum) {
+        lastSum += checkOdd(num);
+        int len = num.length();
+        if(len >= 3) { // 나누기
+            for(int i =1;i<=len-2;i++) {
+                for(int j =1;j<=len-2;j++) {
+                    int k = len-i-j;
+                    if(k<=0) continue;
+                    int num1 = Integer.parseInt(num.substring(0, i));
+                    int num2 = Integer.parseInt(num.substring(i, i+j));
+                    int num3 = Integer.parseInt(num.substring(i+j, i+j+k));
+                    func(String.valueOf(num1+num2+num3), lastSum);
+                }
+            }
+        }
+        else if(len == 2) { // 합치기
+            int num1 = Integer.parseInt(num.substring(0, 1));
+            int num2 = Integer.parseInt(num.substring(1, 2));
+            func(String.valueOf(num1+num2), lastSum);
+        }
+        else{ // 길이가 1일때 최소 최대 판별
+            max = Math.max(max, lastSum);
+            min = Math.min(min, lastSum);
+            return lastSum;
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ / Programmers
- 문제 번호: 20164
- 문제 링크: https://www.acmicpc.net/problem/20164
- 풀이 시간: 33:54
- 분류: 구현, 재귀

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 재귀를 통한 브루트포스 알고리즘
- 사용한 알고리즘/자료구조: 재귀, 브루트포스

## 2) 시간/공간 복잡도

- 시간 복잡도: O(3*len(n)) - 사실 잘 모르겠음 애매함, 최대 길이가 9이므로 3개로 분할하는 경우 28개이지만 또한 안에서 분할하기 때문 많아도 엄청 커지질 않음
- 공간 복잡도: O(len(n)) - 재귀 스택

---

# 📝 기타

- 최대값을 1000000으로 설정하였지만 좀 더 명확할 필요가 있음(후회)
- 시간이 생각보다 오래 소요됨(아쉬움)
- 알고리즘은 야무지게 짠듯(뿌듯)
