### PR TITLE
Solve(divide_conquer): BOJ 17829 "222-폴링" 문제 풀이

### DIFF
--- a/boj/solved/divide_conquer/17829/Main.java
+++ b/boj/solved/divide_conquer/17829/Main.java
@@ -1,0 +1,40 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int n;
+    static int[][] matrix;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        matrix = new int[n][n];
+        for(int i =0;i<n;i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for(int j = 0;j<n;j++) {
+                matrix[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // matrix를 축소시켜나가면서 matrix에 저장
+        for(int i = n;i>0;i/=2) {
+            recursion(0, 0, n);
+        }
+        System.out.println(matrix[0][0]);
+    }
+
+    public static void recursion(int x, int y, int size) {
+        // size가 2일경우 기존 matrix에서 1/4부분만 갱신(메모리 절약)
+        if(size == 2) {
+            int[] tmp = new int[]{matrix[x][y], matrix[x+1][y], matrix[x][y+1], matrix[x+1][y+1]};
+            Arrays.sort(tmp);
+            matrix[x/size][y/size] = tmp[2];
+            return;
+        }
+
+        int halfSize = size/2;
+        recursion(x, y, halfSize);
+        recursion(x+halfSize, y, halfSize);
+        recursion(x, y + halfSize, halfSize);
+        recursion(x+halfSize, y + halfSize, halfSize);
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 17829
- 문제 링크: https://www.acmicpc.net/problem/17829
- 풀이 시간: 15:26
- 분류: 분할정복

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 회귀를 사용한 분할 정복
- 사용한 알고리즘/자료구조: 분할정복

## 2) 시간/공간 복잡도

- 시간 복잡도: O(n^2) : 
    - 한번의 분할정복에서 하는 계산은 총 n^2/4번이다. 
    - 총 recursion 메서드의 호출은 log(n)번 일어나므로 O(n^2logn)으로 생각하였지만 recursion을 반복할 수록 n이 줄어드므로 나에겐 계산이 어려워서 gpt의 힘을 빌렸다.
    - n의 최대값이 1024이므로 1초내에는 가능할 것이라고 생각하였지만 두려움이 있었다. 결국, 통과해 버렸다..
- 공간 복잡도: O(n^2)
    - 스택공간은 O(logn) 이다.
---

# 🎯 리뷰 요청 포인트

- 검토받고 싶은 부분: x
- 더 효율적인 풀이 가능 여부: o
- 코드 스타일 / 구조 개선 의견 요청: o

---

# 📝 기타

- 나의 약한 부분인 분할정복 문제를 풀었다. 초반 문제 유형을 파악하기는 쉬웠다. 하지만 확신을 가지고 엄청 쉽게는 풀리지 않는 것 같다.
