### PR TITLE
Solve(greedy): BOJ 17521 "Byte Coin" 문제 풀이

### DIFF
--- a/boj/solved/greedy/17521/Main.java
+++ b/boj/solved/greedy/17521/Main.java
@@ -1,0 +1,49 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int n;
+    static long w;
+    static long coin = 0;
+    static int[] arr;
+    static int[] check; //0 유지 1 감소 2 증가
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        n = Integer.parseInt(st.nextToken());
+        w = Integer.parseInt(st.nextToken());
+
+        arr = new int[n];
+        check = new int[n];
+        for(int i =0;i<n;i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+        
+        for(int i = 0;i<n-1;i++) {
+            if(arr[i] < arr[i+1]) {
+                check[i] = 2;
+            }
+            else if(arr[i] > arr[i+1]) {
+                check[i] = 1;
+            }
+            else{
+                check[i] = 0;
+            }
+        }
+
+        for(int i = 0;i<n-1;i++) {
+            if(check[i] == 2) { // 구매
+                long tmp = (long)w / arr[i];
+                coin += tmp;
+                w = w % arr[i];
+            }
+            else if(i>0 && check[i] == 1 && check[i-1] != 1) { // 판매
+                w += coin * arr[i];
+                coin = 0;
+            }
+        }
+        w += coin * arr[n-1];
+        System.out.println(w);
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 17521
- 문제 링크: https://www.acmicpc.net/problem/17521
- 풀이 시간: 21:31
- 분류: 그리디

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 구매와 판매의 조건을 통한 그리디 알고리즘
- 사용한 알고리즘/자료구조: 그리디

## 2) 시간/공간 복잡도

- 시간 복잡도: O(N)
- 공간 복잡도: O(N)
---

# 🎯 리뷰 요청 포인트

- 검토받고 싶은 부분:
- 더 효율적인 풀이 가능 여부:
- 코드 스타일 / 구조 개선 의견 요청:

---

# 📝 기타

나올 수 있는 가장 큰 정답은 50^7 * 100000 이라 long으로 문제를 해결하였다. 하지만 돈만 long으로 계산하고 코인은 int로 해서 문제를 틀렸다.


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
