### PR TITLE
Solve(dp): BOJ 2631 "줄세우기" 문제 풀이

### DIFF
--- a/boj/solved/dp/2631/Main.java
+++ b/boj/solved/dp/2631/Main.java
@@ -1,0 +1,38 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int n;
+    static int[] arr;
+    static int[] dp;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        arr = new int[n];
+        dp = new int[n]; // i번째까지의 최장 증가 수열 길이
+
+        for(int i = 0;i<n;i++) {
+            arr[i] = Integer.parseInt(br.readLine());
+        }
+        
+        dp[0] = 1;
+        for(int i = 1;i<n;i++) {
+            for(int j = 0;j<i;j++) {
+                if(arr[i] > arr[j]) {
+                    dp[i] = Math.max(dp[i], dp[j] +1);
+                }
+            }
+            if(dp[i] == 0) {
+                dp[i] = 1;
+            }
+        }
+
+        int lcs = 0;
+        for(int i = 0;i<n;i++) {
+            lcs = Math.max(lcs, dp[i]);
+        }
+
+
+        System.out.println(n - lcs);
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 2631
- 문제 링크: https://www.acmicpc.net/problem/2631
- 풀이 시간: 35:31
- 분류: dp

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: (gpt 힌트 얻음) 최장거리수열을 dp로 저장해나가며, 최종적으로 전체 길이에서 최장 거리 수열을 뺸 값이 정답이 됨
- 사용한 알고리즘/자료구조: dp, LIS

## 2) 시간/공간 복잡도

- 시간 복잡도: O(N*log(N))
- 공간 복잡도: O(N)

---

# 🎯 리뷰 요청 포인트

- 검토받고 싶은 부분:
- 더 효율적인 풀이 가능 여부:
- 코드 스타일 / 구조 개선 의견 요청:

---

# 📝 기타

초반에 알고리즘의 규칙을 찾으려고 노력했었다. 자신보다 큰값의 개수를 수집해서 해결하려고 시도하고, 뒤집힌 번호의 개수를 구하기도 하였다.
문제자체는 쉬웠지만, 결국 문제 풀이 방법을 찾는 과정을 알기 쉽지 않았다. gpt에게 LIS를 사용하라는 힌트를 얻고나서는 수월하게 해결 가능하였다.


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
