### PR TITLE
Solve(brute_force): BOJ 1038 "감소하는 수" 문제 풀이

### DIFF
--- a/boj/solved/brute_force/1038/Main.java
+++ b/boj/solved/brute_force/1038/Main.java
@@ -1,0 +1,34 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int n;
+    static List<Long> dp;
+    
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        dp = new ArrayList<>();
+        
+        for(int i = 0;i<10;i++) {
+            recursion(i, i);
+        }
+        dp.sort(Comparator.naturalOrder());
+
+        if(n >= dp.size()) {
+            System.out.println(-1);
+        }
+        else{
+            System.out.println(dp.get(n));
+        }
+    }
+
+    public static void recursion(long num, long lastNum) {
+        dp.add(num);
+        
+        for(int i = 0;i<lastNum;i++) {
+            recursion(num*10+i, i);
+        }
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ 
- 문제 번호: 1038
- 문제 링크: https://www.acmicpc.net/problem/1038
- 풀이 시간: 17:35
- 분류: 브루트포스, 회귀

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 감소하는 수 전체를 리스트에 저장
- 사용한 알고리즘/자료구조: 브루트포스

## 2) 시간/공간 복잡도

- 시간 복잡도: O(1023)
- 공간 복잡도: O(1023)

---

# 📝 기타

- 예전에 풀었던 문제인 것 같지만, 해결방법이 간단하게 생각나지 않았다.
- 나름 쉽게 풀이했던것 같다.


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
