### PR TITLE
Solve(brute_force): BOJ 14225 "부분수열의 합" 문제 풀이

### DIFF
--- a/boj/solved/brute_force/14225/Main.java
+++ b/boj/solved/brute_force/14225/Main.java
@@ -1,0 +1,34 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int n;
+    static int[] arr;
+    static boolean[] dp;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        arr = new int[n];
+        dp = new boolean[2000001];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i = 0;i<n;i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+        recursion(0,0);
+
+        int i = 0;
+        for(i = 0;i<2000001;i++) {
+            if(!dp[i]) {
+                break;
+            }
+        }
+        System.out.println(i);
+    }
+
+    public static void recursion(int idx, int sum) { 
+        dp[sum] = true;
+        if(idx == n) return;
+        recursion(idx+1, sum + arr[idx]);
+        recursion(idx+1, sum);
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 14225
- 문제 링크: https://www.acmicpc.net/problem/14225
- 풀이 시간: 14:59
- 분류: 브루트 포스

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 각각의 수를 포함하고 안하고를 반복해서 모든 경우를 저장
- 사용한 알고리즘/자료구조: 브루트 포스

## 2) 시간/공간 복잡도

- 시간 복잡도: O(2^N) n의 최대값이 20이니 충분
- 공간 복잡도: O(200000)

---


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
