### PR TITLE
Solve(brute_force): BOJ 2436 "공약수" 문제 풀이

### DIFF
--- a/boj/solved/brute_force/2436/Main.java
+++ b/boj/solved/brute_force/2436/Main.java
@@ -1,0 +1,49 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int a, b;
+    static List<int[]> nums = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        a = Integer.parseInt(st.nextToken());
+        b = Integer.parseInt(st.nextToken());
+        for(int i = a; i<=b;i+=a) {
+            if (b % i == 0) {
+                nums.add(new int[]{i, (int)i/a, (int)b/i});
+            }
+        }
+        
+        int min = 200000001;
+        int resA = a;
+        int resB = b;
+        for(int i = 0;i<nums.size();i++) {
+            for(int j = i+1;j<nums.size();j++) {
+                if(min > nums.get(i)[0] + nums.get(j)[0] && gcd(nums.get(i)[1], nums.get(j)[1]) == 1 && gcd(nums.get(i)[2], nums.get(j)[2]) == 1) {
+                    min = nums.get(i)[0] + nums.get(j)[0];
+                    resA = nums.get(i)[0];
+                    resB = nums.get(j)[0];
+                }
+            }
+        }
+
+        System.out.println(resA + " " + resB);
+    }
+
+    public static int gcd(int a, int b) {
+    if(b == 0) {
+        return a;
+    }
+    return gcd(b, a % b);
+}
+}
+
+
+// 6 12 18 24 30 36
+// 1 2  3. 4  5. 6
+// 3015 10 x. 6. 5
+
+// a의 배수 b의 약수 중 가중치가 서로소인 수


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ 
- 문제 번호: 2436
- 문제 링크: https://www.acmicpc.net/problem/2436
- 풀이 시간: 19:58
- 분류: 브루트포스

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 최대 공약수, 최소 공배수가 되기 위해서는 서로의 배수, 약수가 공통으로 되는 것들 중 가중치가 서로소인 두개의 수를 찾아야한다는 규칙을 찾음(ex. 6, 180의 답인 30, 36은 최대 공약수(5,6), 최소공배수(6,5)의 가중치를 가짐)
- 사용한 알고리즘/자료구조: 브루트 포스, 유클리드 호제법

## 2) 시간/공간 복잡도

- 시간 복잡도: O(루트(N)^2)
- 공간 복잡도: O(루트(N))

---

# 📝 기타

- 다른 풀이를 보니 공식을 사용해서 가중치를 한번만 구해도 문제가 없다는 것을 알 수 있었다.


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
