### PR TITLE
Solve(two_pointer): BOJ 30804 "과일 탕후루" 문제 풀이

### DIFF
--- a/boj/solved/two_pointer/30804/Main.java
+++ b/boj/solved/two_pointer/30804/Main.java
@@ -1,0 +1,44 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int n;
+    static int[] fruits;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+        fruits = new int[n];
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for(int i = 0; i<n;i++) {
+            fruits[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[] count = new int[10];
+        int l = 0;
+        int r = 0;
+        int typeCount = 0;
+        int res = 0;
+
+        while (r < n) {
+            if (count[fruits[r]] == 0) {
+                typeCount++;
+            }
+            count[fruits[r]]++;
+            r++;
+
+            while (typeCount > 2) {
+                count[fruits[l]]--;
+                if (count[fruits[l]] == 0) {
+                    typeCount--;
+                }
+                l++;
+            }
+
+            res = Math.max(res, r - l);
+        }
+
+        System.out.println(res);
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 30804
- 문제 링크: https://www.acmicpc.net/problem/30804
- 풀이 시간: 8:42
- 분류: two pointer

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 투포인터로 과일 개수 카운트
- 사용한 알고리즘/자료구조: 투포인터

## 2) 시간/공간 복잡도

- 시간 복잡도: O(2*N)
- 공간 복잡도: O(N)

---

# 📝 기타

- 누적합을 쓸까도 고민하였지만 과일 개수가 9개로 제한이 되어서 그냥 투포인터로 해결하였다.


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
