### PR TITLE
Solve(math): BOJ 17387 "선분 교차 2" 문제 풀이

### DIFF
--- a/boj/solved/math/17387/Main.java
+++ b/boj/solved/math/17387/Main.java
@@ -1,0 +1,53 @@
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        st = new StringTokenizer(br.readLine());
+        long x1 = Long.parseLong(st.nextToken());
+        long y1 = Long.parseLong(st.nextToken());
+        long x2 = Long.parseLong(st.nextToken());
+        long y2 = Long.parseLong(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        long x3 = Long.parseLong(st.nextToken());
+        long y3 = Long.parseLong(st.nextToken());
+        long x4 = Long.parseLong(st.nextToken());
+        long y4 = Long.parseLong(st.nextToken());
+
+        System.out.println(isIntersect(x1, y1, x2, y2, x3, y3, x4, y4) ? 1 : 0);
+    }
+
+    static boolean isIntersect(long x1, long y1, long x2, long y2, long x3, long y3, long x4, long y4) {
+        int res1 = ccw(x1, y1, x2, y2, x3, y3);
+        int res2 = ccw(x1, y1, x2, y2, x4, y4);
+        int res3 = ccw(x3, y3, x4, y4, x1, y1);
+        int res4 = ccw(x3, y3, x4, y4, x2, y2);
+
+        if (res1 * res2 <= 0 && res3 * res4 <= 0) {
+            if (res1 * res2 == 0 && res3 * res4 == 0) {
+                return Math.max(x1, x2) >= Math.min(x3, x4) &&
+                       Math.max(x3, x4) >= Math.min(x1, x2) &&
+                       Math.max(y1, y2) >= Math.min(y3, y4) &&
+                       Math.max(y3, y4) >= Math.min(y1, y2);
+            }
+            return true;
+        }
+        return false;
+    }
+
+    static int ccw(long x1, long y1, long x2, long y2, long x3, long y3) {
+        long val = (x1 * y2 + x2 * y3 + x3 * y1) - (y1 * x2 + y2 * x3 + y3 * x1);
+        if (val > 0) {
+            return 1;
+        }
+        if (val < 0) {
+            return -1;
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 17387
- 문제 링크: https://www.acmicpc.net/problem/17387
- 풀이 시간: 1:21:03
- 분류: CCW, math

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: ccw 알고리즘을 사용해서 풀이(일직선과 교차하지 않을 경우를 잘생각해서 해결)
- 사용한 알고리즘/자료구조: CCW

## 2) 시간/공간 복잡도

- 시간 복잡도: O(1)
- 공간 복잡도: O(1)

---

# 📝 기타

- ccw 알고리즘 없이 풀어보려고 하였지만, 너무 하드했다..


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
