### PR TITLE
Solve(dp): BOJ 1562 "계단 수" 문제 풀이

### DIFF
--- a/boj/solved/dp/1562/Main.java
+++ b/boj/solved/dp/1562/Main.java
@@ -1,0 +1,37 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int n;
+    static int[][][] dp; // i길이인 j로 끝나고 비트마스킹인 계단수의 수
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        dp = new int[n+1][10][1024];
+        for(int i = 1;i<10;i++) {
+            dp[1][i][1 << i] = 1;
+        }
+        
+        for(int i = 2;i<=n;i++) {
+            for(int j = 0;j<10;j++) {
+                for(int k = 0;k<1024;k++) {
+                    if(j-1 >= 0) {
+                        dp[i][j][k | (1<<j)] = (dp[i][j][k | (1<<j)] + dp[i - 1][j - 1][k]) % 1_000_000_000;
+                    }
+                    if(j+1 < 10) {
+                        dp[i][j][k | (1<<j)] = (dp[i][j][k | (1<<j)] + dp[i - 1][j + 1][k]) % 1_000_000_000;
+                    }
+                }
+            }
+        }
+        
+        long res = 0;
+        for(int i = 0;i<10;i++) {
+            res = (res + dp[n][i][1023]) % 1_000_000_000;
+        }
+
+        System.out.println(res);
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 1562
- 문제 링크: https://www.acmicpc.net/problem/1562
- 풀이 시간: 38:06
- 분류: dp, 비트마스킹

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 기존 계단 수 풀이에 비트마스킹을 추가해서 풀이
- 사용한 알고리즘/자료구조: dp, 비트마스킹

## 2) 시간/공간 복잡도

- 시간 복잡도: O(N*10*1024)
- 공간 복잡도: O(N*10*1024)

---

# 📝 기타

- 비트마스킹으로 풀이하는 것을 인지하면 풀만한 문제
- 비트마스킹 문제를 더 풀어볼 필요가 있을 듯


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
