### PR TITLE
Solve(dp): BOJ 2098 "외판원 순회" 문제 풀이

### DIFF
--- a/boj/solved/dp/2098/Main.java
+++ b/boj/solved/dp/2098/Main.java
@@ -1,0 +1,49 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int n;
+    static int[][] w;
+    static int[][] dp; // i의 도시에 도착했을때 비트마스킹 k의 도시를 방문 했을때의 최솟값
+    static int INF = 16_000_000;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        n = Integer.parseInt(br.readLine());
+
+        w = new int[n][n];
+        for(int i = 0;i<n;i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for(int j = 0;j<n;j++) {
+                w[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+        dp = new int[n][1 << n];
+        for(int i = 0;i<n;i++) {
+            Arrays.fill(dp[i], -1);
+        }
+        System.out.println(tsp(0, 1)); // 어느 위치에서 시작하던지 최솟값은 같음
+    }
+
+    public static int tsp(int city, int mask) {
+        if (mask == (1<<n) -1) { // 모두 방문했을 경우
+            if (w[city][0] == 0) {
+                return INF;
+            } 
+            return w[city][0];
+        }
+
+        if (dp[city][mask] != -1) { // 이미 계산된 경우
+            return dp[city][mask];
+        }
+
+        dp[city][mask] = INF;
+
+        for(int i = 0;i<n;i++) {
+            if((mask & (1 <<i)) == 0 && w[city][i] != 0) { // 방문하지 않았고 이동할 수 있는 경우
+                dp[city][mask] = Math.min(dp[city][mask], tsp(i, mask | (1<<i)) + w[city][i]);
+            }
+        }
+
+        return dp[city][mask];
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 2098
- 문제 링크: https://www.acmicpc.net/problem/2098
- 풀이 시간: 51:29
- 분류: dp, 비트마스킹

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 비트마스킹으로 방문 도시를 체크하고 현재 위치에서 진행할 수 있는 최소 이동값을 메모라이제이션 해서 답을 얻는 풀이
- 사용한 알고리즘/자료구조: dp, 비트마스킹

## 2) 시간/공간 복잡도

- 시간 복잡도: O(N^2 * 2^N)
- 공간 복잡도: O(N * 2^N)

---

# 📝 기타

- TSP 알고리즘을 공부하고 풀이를 진행했는데도 어려웠던 문제
- 비트마스킹에 대한 감은 찾았지만, 회귀에 대한 이해도가 부족했음(반복문 풀이가 좀 더 쉬운 것 같긴하다.)


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
