### PR TITLE
Solve(topology_sort): BOJ 9470 "Strahler 순서" 문제 풀이

### DIFF
--- a/boj/solved/topology_sort/9470/Main.java
+++ b/boj/solved/topology_sort/9470/Main.java
@@ -1,0 +1,72 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int t;
+    static int k,m,p;
+    static List<Integer>[] nodes;
+    static int[] sequences;
+    static int[] strahler;
+    static boolean[] visited; // 들어오는 강의 최댓값이 2개이상 들어왔는가
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        t = Integer.parseInt(br.readLine());
+        while(t--> 0) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            k = Integer.parseInt(st.nextToken());
+            m = Integer.parseInt(st.nextToken());
+            p = Integer.parseInt(st.nextToken());
+            nodes = new List[m+1];
+            for(int i = 0;i<=m;i++) {
+                nodes[i] = new ArrayList<>();
+            }
+            sequences = new int[m+1];
+            strahler = new int[m+1];
+            visited = new boolean[m+1];
+            for(int i = 0;i<p;i++) {
+                st = new StringTokenizer(br.readLine());
+                int a = Integer.parseInt(st.nextToken());
+                int b = Integer.parseInt(st.nextToken());
+                nodes[a].add(b);
+                sequences[b] += 1;
+            }
+
+            Queue<Integer> q = new LinkedList<>();
+            // 루트 노드 큐에 넣기
+            for(int i = 1;i<=m;i++) {
+                if(sequences[i] == 0) {
+                    strahler[i] = 1;
+                    q.add(i);
+                }
+            }
+            
+            while(!q.isEmpty()) {
+                int node = q.poll();
+                for(int tmp : nodes[node]) {
+                    sequences[tmp] -=1;
+                    if(strahler[tmp] == strahler[node]) {
+                        visited[tmp] = true;
+                    }
+                    if (strahler[tmp] < strahler[node]) {
+                        strahler[tmp] = strahler[node];
+                        visited[tmp] = false;
+                    }
+                    
+                    if (sequences[tmp] == 0) {
+                        q.add(tmp);
+                        if (visited[tmp]) {
+                            strahler[tmp] +=1;
+                        }
+                    }
+                }
+            }
+            
+            sb.append(k + " " + strahler[m] + "\n");
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 9470
- 문제 링크: https://www.acmicpc.net/problem/9470
- 풀이 시간: 36:22
- 분류: 위상정렬

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 위상정렬을 사용하여 강의 순서를 정하여 풀이
- 사용한 알고리즘/자료구조: 위상정렬

## 2) 시간/공간 복잡도

- 시간 복잡도: O(T*(M+P))
- 공간 복잡도: O(M + P)

---



<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
