### PR TITLE
Solve(brute_force): BOJ 2531 "회전 초밥" 문제 풀이

### DIFF
--- a/boj/solved/brute_force/2531/Main.java
+++ b/boj/solved/brute_force/2531/Main.java
@@ -1,0 +1,52 @@
+import java.io.*;
+import java.util.*;
+
+class Main {
+    static int n, d, k, c;
+    static int[] cycle;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        d = Integer.parseInt(st.nextToken());
+        k = Integer.parseInt(st.nextToken());
+        c = Integer.parseInt(st.nextToken());
+        
+        cycle = new int[n];
+        for(int i = 0;i<n;i++) {
+            cycle[i] = Integer.parseInt(br.readLine());
+        }
+
+        int[] sushi = new int[d+1];
+        int count = 0;
+        int res = 0;
+        for(int i = 0;i<k;i++) {
+            if (sushi[cycle[i]] == 0) {
+                count +=1;
+            }
+            sushi[cycle[i]] +=1;
+            res = Math.max(res, count);
+        }
+
+        for(int i = 0;i<n;i++) { // 앞에 초밥(i)을 빼고 뒤의 초밥(i+k)을 추가   
+            sushi[cycle[i]] -= 1;
+            if (sushi[cycle[i]] == 0) {
+                count -=1;
+            }
+
+            if (sushi[cycle[(i+k) % n]] == 0) {
+                count +=1;
+            }
+            sushi[cycle[(i+k) % n]] += 1;
+
+            if (sushi[c] == 0) {
+                res = Math.max(res, count + 1);
+            }
+            else {
+                res = Math.max(res, count);
+            }
+        }
+        
+        System.out.println(res);
+    }
+}


### PR DESCRIPTION
# 📘 문제 정보

- 플랫폼: BOJ
- 문제 번호: 2531
- 문제 링크: https://www.acmicpc.net/problem/2531
- 풀이 시간: 16:21
- 분류: 브루트 포스, 슬라이딩 윈도우

---

# ✅ 정답(PR)인 경우 작성

## 1) 최종 풀이 요약

- 해결 방법 핵심: 슬라이딩 윈도우를 활용하여 모든 행사에 참여할 수 있는 경우를 전부 계산
- 사용한 알고리즘/자료구조: 브루트 포스, 슬라이딩 윈도우

## 2) 시간/공간 복잡도

- 시간 복잡도: O(N)
- 공간 복잡도: O(N)

---

# 📝 기타

- 처음 HashSet을 사용하여 풀이 하려고 하였으나 O(NK)로 시간초과가 발생하여, 슬라이딩 윈도우 방식으로 풀이함


<!-- Copilot은 리뷰에 관한 모든 내용을 한국어로 대답해주세요.  -->
